### PR TITLE
Move mime type to seperate table

### DIFF
--- a/api/src/main/java/api/controllers/users/UserAvatarController.java
+++ b/api/src/main/java/api/controllers/users/UserAvatarController.java
@@ -93,7 +93,7 @@ public class UserAvatarController {
         ByteArrayResource resource = new ByteArrayResource(bytes);
 
         return ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType(s3Object.getMediaType()))
+            .contentType(MediaType.parseMediaType(s3Object.getMimeType().getName()))
             .contentLength(bytes.length)
             .body(resource);
     }
@@ -214,7 +214,7 @@ public class UserAvatarController {
         ByteArrayResource resource = new ByteArrayResource(bytes);
 
         return ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType(s3Object.getMediaType()))
+            .contentType(MediaType.parseMediaType(s3Object.getMimeType().getName()))
             .contentLength(bytes.length)
             .body(resource);
     }

--- a/api/src/main/java/api/entities/Authority.java
+++ b/api/src/main/java/api/entities/Authority.java
@@ -2,6 +2,7 @@ package api.entities;
 
 import org.springframework.security.core.GrantedAuthority;
 
+import io.micrometer.common.lang.NonNull;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -27,6 +28,7 @@ public class Authority implements GrantedAuthority {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @Column(unique = true)
+    @NonNull
+    @Column(unique = true, nullable = false)
     private String authority;
 }

--- a/api/src/main/java/api/entities/MimeType.java
+++ b/api/src/main/java/api/entities/MimeType.java
@@ -6,8 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,26 +13,20 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * {@link S3Object}.
+ * {@link MimeType}.
  */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "s3objects")
-public class S3Object {
+@Table(name = "mime_types")
+public class MimeType {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     @NonNull
-    @Column(name = "object_key", unique = true, nullable = false)
-    private String key;
-
-    private long size;
-
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "mime_type_id", nullable = false)
-    private MimeType mimeType;
+    @Column(unique = true, nullable = false)
+    private String name;
 }

--- a/api/src/main/java/api/entities/Role.java
+++ b/api/src/main/java/api/entities/Role.java
@@ -3,6 +3,7 @@ package api.entities;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.micrometer.common.lang.NonNull;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -33,7 +34,8 @@ public class Role {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @Column(unique = true)
+    @NonNull
+    @Column(unique = true, nullable = false)
     private String name;
 
     @Default

--- a/api/src/main/java/api/entities/User.java
+++ b/api/src/main/java/api/entities/User.java
@@ -41,7 +41,7 @@ public class User implements UserDetails {
     private int id;
 
     @NonNull
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private String username;
     private String password;
 

--- a/api/src/main/java/api/repositories/MimeTypeRepository.java
+++ b/api/src/main/java/api/repositories/MimeTypeRepository.java
@@ -1,0 +1,22 @@
+package api.repositories;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import api.entities.MimeType;
+
+/**
+ * {@link MimeTypeRepository}.
+ */
+@Repository
+public interface MimeTypeRepository extends JpaRepository<MimeType, Integer> {
+    /**
+     * Find mime type object by name.
+     *
+     * @param name mime type name
+     * @return {@link Optional} {@link MimeType}
+     */
+    public Optional<MimeType> findByName(String name);
+}

--- a/api/src/main/java/api/repositories/RoleRepository.java
+++ b/api/src/main/java/api/repositories/RoleRepository.java
@@ -15,8 +15,8 @@ public interface RoleRepository extends JpaRepository<Role, Integer> {
     /**
      * Find role object by role name.
      *
-     * @param role role name
+     * @param name role name
      * @return {@link Optional} {@link Role}
      */
-    public Optional<Role> findByName(String role);
+    public Optional<Role> findByName(String name);
 }

--- a/api/src/main/java/api/services/MimeTypeService.java
+++ b/api/src/main/java/api/services/MimeTypeService.java
@@ -1,0 +1,55 @@
+package api.services;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import api.entities.MimeType;
+import api.repositories.MimeTypeRepository;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link MimeTypeService}.
+ */
+@Slf4j
+@Service
+public class MimeTypeService {
+    @Autowired
+    private MimeTypeRepository mimeTypeRepository;
+
+    /**
+     * Find mime type.
+     *
+     * @param name mime type name
+     * @return {@link Optional} {@link MimeType}
+     */
+    @Transactional(readOnly = true)
+    public Optional<MimeType> find(String name) {
+        return mimeTypeRepository.findByName(name);
+    }
+
+    /**
+     * Save mime type.
+     *
+     * @param mimeType mime type
+     * @return {@link MimeType}
+     */
+    @Transactional
+    public MimeType save(MimeType mimeType) {
+        log.info("Mime type saved: " + mimeType);
+        return mimeTypeRepository.save(mimeType);
+    }
+
+    /**
+     * Gets mime type by name and creates it if non-existent.
+     *
+     * @param name mime type name
+     * @return {@link MimeType}
+     */
+    @Transactional
+    public MimeType getOrCreateByName(String name) {
+        return find(name).orElseGet(() -> save(MimeType.builder().name(name).build()));
+    }
+}

--- a/api/src/main/java/api/services/UserService.java
+++ b/api/src/main/java/api/services/UserService.java
@@ -20,6 +20,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import api.dtos.UserDto;
+import api.entities.MimeType;
 import api.entities.Role;
 import api.entities.S3Object;
 import api.entities.User;
@@ -41,6 +42,8 @@ public class UserService implements UserDetailsService {
     private UserMapper userMapper;
     @Autowired
     private S3ObjectService s3ObjectService;
+    @Autowired
+    private MimeTypeService mimeTypeService;
 
     @Value("${api.avatar.max:5000000}")
     private long maxAvatarSize;
@@ -277,10 +280,11 @@ public class UserService implements UserDetailsService {
         }
 
         final S3Object oldAvatar = user.getAvatar();
+        MimeType mimeType = mimeTypeService.getOrCreateByName(contentType);
         S3Object newAvatar = S3Object.builder()
             .key(S3ObjectService.AVATAR_DIR + user.getId() + "_" + UUID.randomUUID())
             .size(avatar.getSize())
-            .mediaType(contentType)
+            .mimeType(mimeType)
             .build();
 
         s3ObjectService.save(newAvatar, avatar.getInputStream());


### PR DESCRIPTION
Create a new media type table for the `S3Object` entity's media type to join to. This table will contain items like `image/png` or `text/plain`. This will reduce the overall size of our database in the common case that `S3Object` entities have the same media type.

AC:
- There is a new table in the database for media types
- S3Objects should have a relationship to this new table (I believe ManyToOne)
- When new S3Objects are created via S3ObjectService, the media type should be created in the new table if it does not already exist. Else it should be found by its name and connected to the S3Object entity

No new tests should need to be created for this, since it should already be adequately tested by the avatar controllers. Just check the test coverage report to be sure.