### PR TITLE
Connect S3Object Entity Listener

### DIFF
--- a/api/src/main/java/api/entities/S3Object.java
+++ b/api/src/main/java/api/entities/S3Object.java
@@ -1,8 +1,10 @@
 package api.entities;
 
+import api.components.S3ObjectEntityListener;
 import io.micrometer.common.lang.NonNull;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -22,6 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@EntityListeners(S3ObjectEntityListener.class)
 @Table(name = "s3objects")
 public class S3Object {
     @Id


### PR DESCRIPTION
**Describe the bug**
When user is deleted, user avatar is not removed.

**To Reproduce**
Run the `shouldDeleteAvatar_whenUserDeleted` with code coverage enabled and observe that the `S3ObjectEntityListener` PreRemove is not hit.

**Expected behavior**
When a user is deleted the PreRemove listener should delete the avatar from S3 before deleting the S3ObjectEntity.

**Screenshots (if applicable)**
<img width="531" height="306" alt="Image" src="https://github.com/user-attachments/assets/042273e0-b321-4e07-82f1-194c90a6de7d" />

**Additional context**
The fix should be to add `@EntityListeners(S3ObjectEntityListener.class)` to `S3Object`.