### PR TITLE
Implemented s3 unit testing

### DIFF
--- a/api/src/main/java/api/controllers/users/UserAvatarController.java
+++ b/api/src/main/java/api/controllers/users/UserAvatarController.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
@@ -45,9 +44,6 @@ public class UserAvatarController {
     private S3ObjectService s3ObjectService;
     @Autowired
     private UserService userService;
-
-    @Value("${api.avatar.max:5000000}")
-    private long maxSize;
 
     /**
      * Get my avatar.

--- a/api/src/main/java/api/services/S3ObjectService.java
+++ b/api/src/main/java/api/services/S3ObjectService.java
@@ -3,6 +3,7 @@ package api.services;
 import java.io.InputStream;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,9 @@ public class S3ObjectService {
     private SimpleStorageService simpleStorageService;
 
     public static final String AVATAR_DIR = "avatar/";
+
+    @Value("${api.s3.max:50000000}")
+    private long maxObjectSize;
 
     /**
      * Download S3 object from storage.
@@ -41,6 +45,9 @@ public class S3ObjectService {
      */
     @Transactional
     public void save(S3Object object, InputStream in) {
+        if (object.getSize() > maxObjectSize) {
+            throw new IllegalArgumentException("File size exceeds limit (" + maxObjectSize + " bytes).");
+        }
         simpleStorageService.uploadObject(object.getKey(), in, object.getSize());
         s3ObjectRepository.save(object);
     }

--- a/api/src/main/java/api/services/UserService.java
+++ b/api/src/main/java/api/services/UserService.java
@@ -45,7 +45,7 @@ public class UserService implements UserDetailsService {
     @Autowired
     private MimeTypeService mimeTypeService;
 
-    @Value("${api.avatar.max:5000000}")
+    @Value("${api.s3.avatar.max:5000000}")
     private long maxAvatarSize;
 
     private static final Set<MediaType> ALLOWED_AVATAR_TYPES = Set.of(

--- a/api/src/main/java/api/services/storage/MinioStorageService.java
+++ b/api/src/main/java/api/services/storage/MinioStorageService.java
@@ -53,6 +53,11 @@ public class MinioStorageService implements SimpleStorageService {
     }
 
     private void uploadObject(String bucket, String key, InputStream stream, long size) {
+        validateKey(key);
+        if (size < 0) {
+            throw new IllegalArgumentException("Size must not be negative.");
+        }
+
         try {
             minioClient.putObject(
                 PutObjectArgs.builder()
@@ -75,6 +80,7 @@ public class MinioStorageService implements SimpleStorageService {
     }
 
     private InputStream downloadObject(String bucket, String key) {
+        validateKey(key);
         try {
             return minioClient.getObject(GetObjectArgs.builder()
                 .bucket(bucket)
@@ -94,6 +100,7 @@ public class MinioStorageService implements SimpleStorageService {
     }
 
     private void deleteObject(String bucket, String key) {
+        validateKey(key);
         try {
             minioClient.removeObject(RemoveObjectArgs.builder()
                 .bucket(bucket)

--- a/api/src/main/java/api/services/storage/SimpleStorageService.java
+++ b/api/src/main/java/api/services/storage/SimpleStorageService.java
@@ -1,11 +1,27 @@
 package api.services.storage;
 
 import java.io.InputStream;
+import java.util.regex.Pattern;
 
 /**
  * {@link SimpleStorageService}.
  */
 public interface SimpleStorageService {
+    Pattern VALID_KEY = Pattern.compile("^(?!/)(?!.*\\./)[a-zA-Z0-9_./\\-]+$");
+
+    /**
+     * Validate key matches required pattern.
+     *
+     * @param key S3 key
+     */
+    default void validateKey(String key) {
+        if (key == null || !VALID_KEY.matcher(key).matches()) {
+            throw new IllegalArgumentException(
+                "Invalid key: '" + key + "'. " + VALID_KEY.pattern()
+            );
+        }
+    }
+
     /**
      * Upload object to the storage system.
      *

--- a/api/src/test/java/api/BasicContext.java
+++ b/api/src/test/java/api/BasicContext.java
@@ -1,4 +1,4 @@
-package api.controllers;
+package api;
 
 import static org.mockito.Mockito.when;
 
@@ -26,7 +26,7 @@ import api.services.TokenService;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = "api.avatar.max=1024"
 )
-public abstract class BasicControllerTest {
+public abstract class BasicContext {
     @Autowired
     private TokenService tokenService;
 

--- a/api/src/test/java/api/BasicContext.java
+++ b/api/src/test/java/api/BasicContext.java
@@ -24,7 +24,10 @@ import api.services.TokenService;
  */
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = "api.avatar.max=1024"
+    properties = """
+        api.s3.max=2048
+        api.s3.avatar.max=1024
+    """
 )
 public abstract class BasicContext {
     @Autowired

--- a/api/src/test/java/api/controllers/AuthenticationControllerTest.java
+++ b/api/src/test/java/api/controllers/AuthenticationControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import api.BasicContext;
 import api.dtos.AuthenticationDto;
 import api.dtos.ErrorDto;
 import api.dtos.LoginDto;
@@ -24,7 +25,7 @@ import api.dtos.RegisterDto;
 /**
  * {@link AuthenticationController} test.
  */
-public class AuthenticationControllerTest extends BasicControllerTest {
+public class AuthenticationControllerTest extends BasicContext {
     @Value("${api.admin.username:admin}")
     private String adminUsername;
     @Value("${api.admin.password:password}")

--- a/api/src/test/java/api/controllers/AuthorityControllerTest.java
+++ b/api/src/test/java/api/controllers/AuthorityControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import api.BasicContext;
 import api.dtos.AuthenticationDto;
 import api.dtos.AuthorityDto;
 import api.dtos.ErrorDto;
@@ -31,7 +32,7 @@ import api.services.AuthorityService;
 /**
  * {@link AuthorityController} test.
  */
-public class AuthorityControllerTest extends BasicControllerTest {
+public class AuthorityControllerTest extends BasicContext {
     @Autowired
     private AuthorityService authorityService;
     @Autowired

--- a/api/src/test/java/api/controllers/HeartbeatControllerTest.java
+++ b/api/src/test/java/api/controllers/HeartbeatControllerTest.java
@@ -9,10 +9,12 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import api.BasicContext;
+
 /**
  * {@link HeartbeatController} test..
  */
-public class HeartbeatControllerTest extends BasicControllerTest {
+public class HeartbeatControllerTest extends BasicContext {
     /**
      * {@link HeartbeatController#heartbeat} test.
      */

--- a/api/src/test/java/api/controllers/RoleControllerTest.java
+++ b/api/src/test/java/api/controllers/RoleControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import api.BasicContext;
 import api.dtos.AuthenticationDto;
 import api.dtos.ErrorDto;
 import api.dtos.RegisterDto;
@@ -37,7 +38,7 @@ import api.services.RoleService;
 /**
  * {@link RoleController} test.
  */
-public class RoleControllerTest extends BasicControllerTest {
+public class RoleControllerTest extends BasicContext {
     @Autowired
     private RoleService roleService;
     @Autowired

--- a/api/src/test/java/api/controllers/users/UserAvatarControllerTest.java
+++ b/api/src/test/java/api/controllers/users/UserAvatarControllerTest.java
@@ -30,8 +30,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import api.BasicContext;
 import api.controllers.AuthenticationController;
-import api.controllers.BasicControllerTest;
 import api.dtos.AuthenticationDto;
 import api.dtos.ErrorDto;
 import api.dtos.RegisterDto;
@@ -44,7 +44,7 @@ import api.services.UserService;
 /**
  * {@link UserAvatarController} test.
  */
-public class UserAvatarControllerTest extends BasicControllerTest {
+public class UserAvatarControllerTest extends BasicContext {
     @Autowired
     private AuthenticationController authenticationController;
     @Autowired
@@ -52,7 +52,7 @@ public class UserAvatarControllerTest extends BasicControllerTest {
     @Autowired
     private S3ObjectService s3ObjectService;
 
-    @Value("${api.avatar.max:5000000}")
+    @Value("${api.avatar.max}")
     private long maxSize;
 
     /**

--- a/api/src/test/java/api/controllers/users/UserAvatarControllerTest.java
+++ b/api/src/test/java/api/controllers/users/UserAvatarControllerTest.java
@@ -52,8 +52,8 @@ public class UserAvatarControllerTest extends BasicContext {
     @Autowired
     private S3ObjectService s3ObjectService;
 
-    @Value("${api.avatar.max}")
-    private long maxSize;
+    @Value("${api.s3.avatar.max}")
+    private long maxAvatarSize;
 
     /**
      * {@link UserAvatarController#getMyAvatar} test.
@@ -393,7 +393,7 @@ public class UserAvatarControllerTest extends BasicContext {
             headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
             // GIVEN: Max size avatar photo
-            int size = (int) (maxSize + 1);
+            int size = (int) (maxAvatarSize + 1);
             byte[] content = new byte[size];
             ByteArrayResource avatar = new ByteArrayResource(content) {
                 @Override
@@ -416,7 +416,7 @@ public class UserAvatarControllerTest extends BasicContext {
                 () -> assertNotNull(responseEntity.getBody()),
                 () -> assertEquals(clock.instant(), responseEntity.getBody().getTimestamp()),
                 () -> assertEquals(
-                    "File size exceeds limit (" + maxSize + " bytes).", responseEntity.getBody().getMessage()
+                    "File size exceeds limit (" + maxAvatarSize + " bytes).", responseEntity.getBody().getMessage()
                 )
             );
         }
@@ -1003,7 +1003,7 @@ public class UserAvatarControllerTest extends BasicContext {
             headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
             // GIVEN: Avatar photo
-            int size = (int) (maxSize + 1);
+            int size = (int) (maxAvatarSize + 1);
             byte[] content = new byte[size];
             ByteArrayResource avatar = new ByteArrayResource(content) {
                 @Override
@@ -1033,7 +1033,7 @@ public class UserAvatarControllerTest extends BasicContext {
                 () -> assertNotNull(responseEntity.getBody()),
                 () -> assertEquals(clock.instant(), responseEntity.getBody().getTimestamp()),
                 () -> assertEquals(
-                    "File size exceeds limit (" + maxSize + " bytes).", responseEntity.getBody().getMessage()
+                    "File size exceeds limit (" + maxAvatarSize + " bytes).", responseEntity.getBody().getMessage()
                 )
             );
         }

--- a/api/src/test/java/api/controllers/users/UserControllerTest.java
+++ b/api/src/test/java/api/controllers/users/UserControllerTest.java
@@ -30,8 +30,8 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import api.BasicContext;
 import api.controllers.AuthenticationController;
-import api.controllers.BasicControllerTest;
 import api.dtos.AuthenticationDto;
 import api.dtos.ErrorDto;
 import api.dtos.LoginDto;
@@ -45,7 +45,7 @@ import io.jsonwebtoken.Jwts;
 /**
  * {@link UserController} test.
  */
-public class UserControllerTest extends BasicControllerTest {
+public class UserControllerTest extends BasicContext {
     @Autowired
     private UserService userService;
     @Autowired

--- a/api/src/test/java/api/controllers/users/UserRoleControllerTest.java
+++ b/api/src/test/java/api/controllers/users/UserRoleControllerTest.java
@@ -22,8 +22,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import api.BasicContext;
 import api.controllers.AuthenticationController;
-import api.controllers.BasicControllerTest;
 import api.dtos.AuthenticationDto;
 import api.dtos.ErrorDto;
 import api.dtos.RegisterDto;
@@ -38,7 +38,7 @@ import api.services.UserService;
 /**
  * {@link UserRoleController} test.
  */
-public class UserRoleControllerTest extends BasicControllerTest {
+public class UserRoleControllerTest extends BasicContext {
     @Autowired
     private UserService userService;
     @Autowired

--- a/api/src/test/java/api/services/storage/S3ObjectServiceTest.java
+++ b/api/src/test/java/api/services/storage/S3ObjectServiceTest.java
@@ -1,0 +1,40 @@
+package api.services.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+import api.BasicContext;
+import api.entities.S3Object;
+import api.services.S3ObjectService;
+
+/**
+ * {@link S3ObjectService} test.
+ */
+public class S3ObjectServiceTest extends BasicContext {
+    @Autowired
+    private S3ObjectService s3ObjectService;
+
+    @Value("${api.s3.max}")
+    private long maxObjectSize;
+
+    @Test
+    public void saveShouldFail_whenSizeTooLarge() {
+        int size = (int) (maxObjectSize + 1);
+        byte[] content = new byte[size];
+
+        S3Object object = S3Object.builder()
+            .size(size)
+            .build();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> s3ObjectService.save(object, new ByteArrayInputStream(content)));
+
+        assertEquals("File size exceeds limit (" + maxObjectSize + " bytes).", ex.getMessage());
+    }
+}

--- a/api/src/test/java/api/services/storage/SimpleStorageServiceTest.java
+++ b/api/src/test/java/api/services/storage/SimpleStorageServiceTest.java
@@ -1,0 +1,223 @@
+package api.services.storage;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import api.BasicContext;
+
+/**
+ * {@link SimpleStorageService} test.
+ */
+public class SimpleStorageServiceTest extends BasicContext {
+    @Autowired(required = false)
+    private MinioStorageService minioStorageService;
+
+    private MemoryStorageService memoryStorageService;
+    private LocalStorageService localStorageService;
+    private List<SimpleStorageService> storages;
+
+    static Stream<Object[]> allPermutations() {
+        List<Object[]> permutations = new ArrayList<>();
+
+        String[] keys = {"key", "", " ", " key", "key ", "/root", "../relative", null};
+        byte[][] streams = {"test".getBytes(), new byte[0], null};
+        long[] sizes = {-1, 0, 1, 100};
+
+        for (String key : keys) {
+            for (byte[] data : streams) {
+                // Correct size
+                if (data != null) {
+                    permutations.add(new Object[]{key, data, data.length});
+                }
+
+                // Other sizes
+                for (long size : sizes) {
+                    permutations.add(new Object[]{key, data, size});
+                }
+            }
+        }
+
+        return permutations.stream();
+    }
+
+    @BeforeEach
+    public void setup() {
+        memoryStorageService = new MemoryStorageService();
+        localStorageService = new LocalStorageService();
+
+        localStorageService.setRootPath("./temp/s3/");
+        localStorageService.init();
+
+        if (minioStorageService != null) {
+            storages = List.of(memoryStorageService, localStorageService, minioStorageService);
+        } else {
+            storages = List.of(memoryStorageService, localStorageService);
+        }
+    }
+
+    @Test
+    public void shouldMatchCaseSensitive() throws IOException {
+        String key = "key";
+        String lowerKey = key.toLowerCase();
+        String upperKey = key.toUpperCase();
+
+        byte[] lowerData = "lower".getBytes();
+        long lowerSize = lowerData.length;
+
+        byte[] upperData = "upper".getBytes();
+        long upperSize = upperData.length;
+
+        String[][] downloads = new String[storages.size()][2];
+        for (String[] row : downloads) {
+            Arrays.fill(row, null);
+        }
+        for (int i = 0; i < storages.size(); i++) {
+            SimpleStorageService s3 = storages.get(i);
+
+            // Upload lower object
+            s3.uploadObject(lowerKey, new ByteArrayInputStream(lowerData), lowerSize);
+
+            // Upload upper object
+            s3.uploadObject(upperKey, new ByteArrayInputStream(upperData), upperSize);
+
+            // Download lower object
+            downloads[i][0] = new String(s3.downloadObject(lowerKey).readAllBytes());
+
+            // Download upper object
+            downloads[i][1] = new String(s3.downloadObject(upperKey).readAllBytes());
+        }
+
+        assertAll(
+            // Downloads match
+            IntStream.range(0, downloads[0].length)
+                .boxed()
+                .flatMap(j ->
+                    IntStream.range(1, storages.size())
+                        .mapToObj(i -> (Executable) () -> {
+                            if (downloads[0][j] != null) {
+                                assertEquals(downloads[0][j], downloads[i][j],
+                                    "Download " + j + " mismatch between storage 0 and " + i);
+                            } else {
+                                assertNull(downloads[i][j],
+                                    "Download " + j + " failed for storage 0, but succeeded for storage " + i);
+                            }
+                        })
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("allPermutations")
+    public void shouldMatchEdgeCases(String key, byte[] data, long size) {
+        byte[] overwriteData = "overwriteData".getBytes();
+        long overwriteSize = overwriteData.length;
+
+        String[][] downloads = new String[storages.size()][3];
+        Exception[][] exceptions = new Exception[storages.size()][6];
+
+        for (String[] row : downloads) {
+            Arrays.fill(row, null);
+        }
+        for (Exception[] row : exceptions) {
+            Arrays.fill(row, null);
+        }
+
+        for (int i = 0; i < storages.size(); i++) {
+            SimpleStorageService s3 = storages.get(i);
+
+            // Upload object
+            try {
+                s3.uploadObject(key, new ByteArrayInputStream(data), size);
+            } catch (Exception e) {
+                exceptions[i][0] = e;
+            }
+
+            // Download object
+            try {
+                downloads[i][0] = new String(s3.downloadObject(key).readAllBytes());
+            } catch (Exception e) {
+                exceptions[i][1] = e;
+            }
+
+            // Overwrite object
+            try {
+                s3.uploadObject(key, new ByteArrayInputStream(overwriteData), overwriteSize);
+            } catch (Exception e) {
+                exceptions[i][2] = e;
+            }
+
+            // Download object
+            try {
+                downloads[i][1] = new String(s3.downloadObject(key).readAllBytes());
+            } catch (Exception e) {
+                exceptions[i][3] = e;
+            }
+
+            // Delete object
+            try {
+                s3.deleteObject(key);
+            } catch (Exception e) {
+                exceptions[i][4] = e;
+            }
+
+            // Download object
+            try {
+                downloads[i][2] = new String(s3.downloadObject(key).readAllBytes());
+            } catch (Exception e) {
+                exceptions[i][5] = e;
+            }
+        }
+
+        List<Executable> all = Stream.concat(
+            // Downloads match
+            IntStream.range(0, downloads[0].length)
+                .boxed()
+                .flatMap(j ->
+                    IntStream.range(1, storages.size())
+                        .mapToObj(i -> (Executable) () -> {
+                            if (downloads[0][j] != null) {
+                                assertEquals(downloads[0][j], downloads[i][j],
+                                    "Download " + j + " mismatch between storage 0 and " + i);
+                            } else {
+                                assertNull(downloads[i][j],
+                                    "Download " + j + " failed for storage 0, but succeeded for storage " + i);
+                            }
+                        })
+                ),
+
+            // Exceptions match
+            IntStream.range(0, exceptions[0].length)
+                .boxed()
+                .flatMap(j ->
+                    IntStream.range(1, storages.size())
+                        .mapToObj(i -> (Executable) () -> {
+                            if (exceptions[0][j] != null) {
+                                assertEquals(exceptions[0][j].getClass(), exceptions[i][j].getClass(),
+                                    "Step " + j + " exception mismatch between storage 0 and " + i);
+                            } else {
+                                assertNull(exceptions[i][j],
+                                    "Step " + j + " no exception for storage 0, but exception for storage " + i);
+                            }
+                        })
+                )
+        ).toList();
+
+        assertAll(all);
+    }
+}


### PR DESCRIPTION
**High-level Overview**
We have three different S3 storage types: Minio (production), Local (development), and Memory (testing). We want to ensure that all three of these function the same so that there are not weird dependencies between environments.

**Description**
Create unit tests which run the same functions with the same input on S3 storage type. Go through all known edge cases: null input, empty string, etc. to see if there are any differences.

**Tests Needed**
[x] Unit Tests
[ ] Integration Tests
[ ] E2E Tests

**Acceptance Criteria**
Each type of S3 storage (Minio, Local, and Memory) has unit testing which goes through all know edge cases to ensure each functions the same.

**Dev Notes**
You may want to have the Minio environment only run when `spring.profiles.active` is `prod` since I don't want to mock the Minio server. For developing this task, you can start up the Minio container and run the tests with `spring.profiles.active=prod` in test application.properties.

I think it would be best if these were parameterized tests with a parameter being the instance of `SimpleStorageService`.